### PR TITLE
modified to follow the "XDG Base Directory Specification"

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -8,10 +8,13 @@ updated: 2019-03-14 by budRich
 EOB
 }
 
-
+if [[ -z $XDG_CONFIG_HOME ]]; then
+  __defaultconfdir="$HOME/.config"
+else
+  __defaultconfdir="$XDG_CONFIG_HOME"
+fi
 # environment variables
-: "${I3MENU_DIR:=$XDG_CONFIG_HOME/i3menu}"
-
+: "${I3MENU_DIR:=$__defaultconfdir/i3menu}"
 
 ___printhelp(){
   

--- a/init.sh
+++ b/init.sh
@@ -8,6 +8,7 @@ updated: 2019-03-14 by budRich
 EOB
 }
 
+
 if [[ -z $XDG_CONFIG_HOME ]]; then
   __defaultconfdir="$HOME/.config"
 else
@@ -15,6 +16,7 @@ else
 fi
 # environment variables
 : "${I3MENU_DIR:=$__defaultconfdir/i3menu}"
+
 
 ___printhelp(){
   

--- a/program.sh
+++ b/program.sh
@@ -9,8 +9,13 @@ EOB
 }
 
 
+if [[ -z $XDG_CONFIG_HOME ]]; then
+  __defaultconfdir="$HOME/.config"
+else
+  __defaultconfdir="$XDG_CONFIG_HOME"
+fi
 # environment variables
-: "${I3MENU_DIR:=$XDG_CONFIG_HOME/i3menu}"
+: "${I3MENU_DIR:=$__defaultconfdir/i3menu}"
 
 
 main(){


### PR DESCRIPTION
Hi, bud! I love your videos!

I installed i3ass to try it out and I found this potential bug using i3menu and i fixed it.
(i3menu was trying to create a "/i3menu" folder because my XDG_CONFIG_HOME wasn't defined)

here is a link to the "XDG Base Directory Specification": [click](https://standards.freedesktop.org/basedir-spec/latest/index.html)

> $XDG_CONFIG_HOME defines the base directory relative to which user specific configuration files should be stored. If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used. 

Note: I didn't edit the documentation